### PR TITLE
change compilation order to workaround windows issue.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,3 +11,5 @@ libraryDependencies ++= Seq(
   "com.novocode" % "junit-interface" % "0.9" % "test->default")
 
 testOptions += Tests.Argument(TestFrameworks.JUnit, "-v", "-a")
+
+compileOrder := CompileOrder.JavaThenScala


### PR DESCRIPTION
Sometimes on windows, no java sources are sent to the
aggressive compiler when there are no scala sources.

Review by @jamesward or someone on the Akka team, like @bantonsson 
